### PR TITLE
fix(test): vitest に browser 解決条件を追加（コンポーネントテストの mount 修正）

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,12 @@ import { sveltekit } from '@sveltejs/kit/vite';
 
 export default defineConfig({
 	plugins: [sveltekit()],
+	// Svelte 5 のクライアント版（mount 等）を解決させる。これが無いと SSR ビルドが
+	// 解決され、コンポーネントテストが
+	// `lifecycle_function_unavailable: mount(...) is not available on the server` で失敗する。
+	resolve: {
+		conditions: ['browser']
+	},
 	test: {
 		environment: 'happy-dom',
 		globals: true,


### PR DESCRIPTION
## 概要

Svelte 5 + vitest の環境で、全コンポーネント描画テストが `lifecycle_function_unavailable: mount(...) is not available on the server` で失敗していた**ベースライン破損の根本原因**を修正します。

`vitest.config.ts` に `resolve.conditions: ['browser']` を追加し、Svelte 5 がクライアント（ブラウザ）版を解決するようにします。これがないと SSR ビルドが解決され、`render()`（内部で `mount`）が動作しません。

## 変更

```diff
 export default defineConfig({
 	plugins: [sveltekit()],
+	resolve: {
+		conditions: ['browser']
+	},
 	test: { ... }
 });
```

## 効果（`bun --bun run test`）

| | Before | After |
|---|---|---|
| Tests | 177 failed / 220 passed / 4 skipped | **106 failed / 291 passed / 4 skipped** |
| Test Files | 6 passed | **8 passed** |

コンポーネントテストが実際に mount するようになり、**+71 件が通過**（例: `PauseOverlay` は 19件中13件パス）。

## 回帰チェック

- 純ロジック spec（`input-validator.spec.ts` 等）は**旧設定と同一の結果**（5 failed / 44 passed）。これらの失敗は本変更前から存在する test-vs-code ドリフトで、本変更とは無関係。
- 本変更は「mount できず失敗していたコンポーネントテスト」を通過に変えるのみで、**previously-passing なテストを壊していない**（回帰ゼロ）。
- `bun --bun run check`: 0 errors。
- `vitest.config.ts` は `vite build` から参照されないため本番ビルドへの影響なし。

## スコープ外（残課題）

残る 106 件の失敗は本 PR の対象外で、別途対応が必要な **test-vs-code ドリフト**です（変更された UI/test-id を参照する古いアサーション、`game.spec.ts` の同期呼び出し問題、romaji マッピングのドリフト等）。本 PR は「コンポーネントテストが mount できる環境」を回復することに限定しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
