### PR TITLE
chore(lint): ESLint エラー108件を解消

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,9 +6,10 @@
       "name": "jomo-karuta-typing-front-app",
       "dependencies": {
         "@lucide/svelte": "^1.17.0",
+        "@opentelemetry/api": "^1.9.1",
         "@supabase/ssr": "^0.10.3",
         "@supabase/supabase-js": "^2.106.2",
-        "dexie": "^4.4.3",
+        "dexie": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/compat": "^2.1.0",
@@ -41,9 +42,9 @@
         "typescript-eslint": "^8.60.0",
         "vite": "^8.0.14",
         "vitest": "^4.1.7",
-        "vitest-browser-svelte": "^2.1.1",
-      },
-    },
+        "vitest-browser-svelte": "^2.1.1"
+      }
+    }
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
@@ -165,6 +166,8 @@
     "@mapbox/node-pre-gyp": ["@mapbox/node-pre-gyp@2.0.3", "", { "dependencies": { "consola": "^3.2.3", "detect-libc": "^2.0.0", "https-proxy-agent": "^7.0.5", "node-fetch": "^2.6.7", "nopt": "^8.0.0", "semver": "^7.5.3", "tar": "^7.4.0" }, "bin": { "node-pre-gyp": "bin/node-pre-gyp" } }, "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.130.0", "", { "os": "android", "cpu": "arm" }, "sha512-h/xYU8/7ADWzVSf5I+YalLpj33LOy9CI/zgbJNIZ5eunRBG+Czqa3lZsvuPHHf3rOt6z1c5+UzoxjbAzAvhwVw=="],
 
@@ -948,6 +951,6 @@
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "svelte-eslint-parser/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "svelte-eslint-parser/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="]
   }
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,17 @@ export default ts.config(
 		rules: {
 			// typescript-eslint strongly recommend that you do not use the no-undef lint rule on TypeScript projects.
 			// see: https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
-			'no-undef': 'off'
+			'no-undef': 'off',
+			// Allow intentionally-unused identifiers prefixed with `_` (e.g. `{#each items as _, i}`,
+			// positional callback params). This is the typescript-eslint recommended convention.
+			'@typescript-eslint/no-unused-vars': [
+				'error',
+				{
+					argsIgnorePattern: '^_',
+					varsIgnorePattern: '^_',
+					caughtErrorsIgnorePattern: '^_'
+				}
+			]
 		}
 	},
 	{

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 	},
 	"dependencies": {
 		"@lucide/svelte": "^1.17.0",
+		"@opentelemetry/api": "^1.9.1",
 		"@supabase/ssr": "^0.10.3",
 		"@supabase/supabase-js": "^2.106.2",
 		"dexie": "^4.4.3"

--- a/src/lib/components/layout/Header.svelte
+++ b/src/lib/components/layout/Header.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import type { User } from '@supabase/supabase-js';
 
 	let { user }: { user: User | null } = $props();
@@ -8,7 +9,7 @@
 	<div class="mx-auto max-w-7xl px-8">
 		<div class="flex h-16 items-center justify-between">
 			<div class="flex">
-				<a href="/" class="-m-1.5 p-1.5 flex items-center">
+				<a href={resolve('/')} class="-m-1.5 p-1.5 flex items-center">
 					<span class="sr-only">上毛かるたタイピング</span>
 					<span class="ml-2 text-xl text-gray-600">上毛かるたタイピング</span>
 				</a>
@@ -16,7 +17,7 @@
 			<div class="flex justify-end">
 				{#if user}
 					<a
-						href="/profile"
+						href={resolve('/profile')}
 						class="text-xl font-semibold leading-6 text-gray-900 hover:text-gray-600"
 					>
 						プロフィール
@@ -24,7 +25,7 @@
 					</a>
 				{:else}
 					<a
-						href="/auth/login"
+						href={resolve('/auth/login')}
 						class="text-xl font-semibold leading-6 text-gray-900 hover:text-gray-600"
 					>
 						ログイン

--- a/src/lib/services/storage/local-storage.spec.ts
+++ b/src/lib/services/storage/local-storage.spec.ts
@@ -9,10 +9,12 @@ import type { GameSettings, UserProfile, SavedSession } from './local-storage';
 // Base64 polyfill for Node.js environment (test only)
 // Happy-dom v20 now provides btoa/atob, but keep as fallback
 if (typeof btoa === 'undefined' && typeof global !== 'undefined') {
-	(global as any).btoa = (str: string) => Buffer.from(str, 'utf-8').toString('base64');
+	(global as unknown as { btoa: (str: string) => string }).btoa = (str: string) =>
+		Buffer.from(str, 'utf-8').toString('base64');
 }
 if (typeof atob === 'undefined' && typeof global !== 'undefined') {
-	(global as any).atob = (str: string) => Buffer.from(str, 'base64').toString('utf-8');
+	(global as unknown as { atob: (str: string) => string }).atob = (str: string) =>
+		Buffer.from(str, 'base64').toString('utf-8');
 }
 
 // LocalStorageのモック
@@ -47,8 +49,11 @@ if (typeof window !== 'undefined') {
 } else {
 	// Node.js環境用
 	if (typeof global !== 'undefined') {
-		(global as any).localStorage = localStorageMock as Storage;
-		(global as any).window = { localStorage: localStorageMock } as any;
+		(global as unknown as { localStorage: Storage }).localStorage =
+			localStorageMock as unknown as Storage;
+		(global as unknown as { window: { localStorage: Storage } }).window = {
+			localStorage: localStorageMock as unknown as Storage
+		};
 	}
 }
 
@@ -119,7 +124,10 @@ describe('LocalStorageService - 初期化', () => {
 
 	it('ストレージが利用できない場合にフォールバックする', () => {
 		// LocalStorageを無効化
-		const globalObj: any = typeof global !== 'undefined' ? global : window;
+		const globalObj = (typeof global !== 'undefined' ? global : window) as unknown as {
+			localStorage: Storage | null;
+			window?: { localStorage: Storage | null };
+		};
 		const originalLocalStorage = globalObj.window?.localStorage || globalObj.localStorage;
 		if (globalObj.window) {
 			Object.defineProperty(globalObj.window, 'localStorage', {
@@ -127,7 +135,7 @@ describe('LocalStorageService - 初期化', () => {
 				writable: true
 			});
 		} else {
-			globalObj.localStorage = null as any;
+			globalObj.localStorage = null;
 		}
 
 		service = new LocalStorageService();
@@ -144,7 +152,7 @@ describe('LocalStorageService - 初期化', () => {
 				writable: true
 			});
 		} else {
-			globalObj.localStorage = originalLocalStorage as any;
+			globalObj.localStorage = originalLocalStorage;
 		}
 	});
 });
@@ -598,7 +606,9 @@ describe('LocalStorageService - パフォーマンス', () => {
 
 	it('大量データでもメモリリークしない', () => {
 		service.initialize();
-		const initialMemory = (performance as any).memory?.usedJSHeapSize || 0;
+		const initialMemory =
+			(performance as unknown as { memory?: { usedJSHeapSize: number } }).memory?.usedJSHeapSize ||
+			0;
 
 		// 1000回の読み書き
 		for (let i = 0; i < 1000; i++) {
@@ -609,7 +619,9 @@ describe('LocalStorageService - パフォーマンス', () => {
 			service.getSettings();
 		}
 
-		const finalMemory = (performance as any).memory?.usedJSHeapSize || 0;
+		const finalMemory =
+			(performance as unknown as { memory?: { usedJSHeapSize: number } }).memory?.usedJSHeapSize ||
+			0;
 		const memoryIncrease = finalMemory - initialMemory;
 
 		// メモリ増加が妥当な範囲内

--- a/src/lib/services/storage/local-storage.ts
+++ b/src/lib/services/storage/local-storage.ts
@@ -3,6 +3,8 @@
  * ゲームデータの永続化を管理
  */
 
+import type { KarutaCard } from '$lib/types/game';
+
 // 型定義
 export interface GameSettings {
 	display: {
@@ -52,10 +54,10 @@ export interface SavedSession {
 	mode: string;
 	startTime: string;
 	cards: {
-		current: any;
+		current: Partial<KarutaCard> | null;
 		currentIndex: number;
-		remaining: any[];
-		completed: any[];
+		remaining: unknown[];
+		completed: unknown[];
 	};
 	score: {
 		total: number;
@@ -67,6 +69,24 @@ export interface SavedSession {
 	timer: {
 		elapsedTime: number;
 		pausedDuration: number;
+	};
+}
+
+/**
+ * saveSession が受け取りうる入力形状
+ * SavedSession 互換のフラットな形状と、GameState 由来のネストした形状の両方を許容する
+ */
+export interface SaveSessionInput {
+	id?: string;
+	mode?: string;
+	startTime?: string;
+	cards?: Partial<SavedSession['cards']>;
+	score?: SavedSession['score'];
+	timer?: SavedSession['timer'];
+	session?: {
+		id?: string;
+		mode?: string;
+		startTime?: string;
 	};
 }
 
@@ -103,7 +123,7 @@ const CURRENT_VERSION = '1.0.0';
  * ローカルストレージサービスクラス
  */
 export class LocalStorageService {
-	private memoryStorage: Map<string, any> = new Map();
+	private memoryStorage: Map<string, string> = new Map();
 	private useMemoryFallback = false;
 
 	constructor() {
@@ -308,14 +328,14 @@ export class LocalStorageService {
 	/**
 	 * セッションを保存
 	 */
-	saveSession(session: SavedSession | any): void {
+	saveSession(session: SaveSessionInput): void {
 		// GameStateから必要な情報のみ抽出
 		const savedSession: SavedSession = {
-			id: session.id || session.session?.id,
-			mode: session.mode || session.session?.mode,
-			startTime: session.startTime || session.session?.startTime,
-			cards: session.cards || {
-				current: session.cards?.current,
+			id: (session.id || session.session?.id) as string,
+			mode: (session.mode || session.session?.mode) as string,
+			startTime: (session.startTime || session.session?.startTime) as string,
+			cards: (session.cards as SavedSession['cards']) || {
+				current: session.cards?.current ?? null,
 				currentIndex: session.cards?.currentIndex || 0,
 				remaining: session.cards?.remaining || [],
 				completed: session.cards?.completed || []
@@ -723,30 +743,32 @@ export class LocalStorageService {
 	/**
 	 * ディープマージ
 	 */
-	private deepMerge(target: any, source: any): any {
-		const output = { ...target };
+	private deepMerge<T>(target: T, source: unknown): T {
+		const output = { ...target } as Record<string, unknown>;
 
 		if (isObject(target) && isObject(source)) {
-			Object.keys(source).forEach((key) => {
-				if (isObject(source[key])) {
-					if (!(key in target)) {
-						Object.assign(output, { [key]: source[key] });
+			const targetObj = target as Record<string, unknown>;
+			const sourceObj = source as Record<string, unknown>;
+			Object.keys(sourceObj).forEach((key) => {
+				if (isObject(sourceObj[key])) {
+					if (!(key in targetObj)) {
+						Object.assign(output, { [key]: sourceObj[key] });
 					} else {
-						output[key] = this.deepMerge(target[key], source[key]);
+						output[key] = this.deepMerge(targetObj[key], sourceObj[key]);
 					}
 				} else {
-					Object.assign(output, { [key]: source[key] });
+					Object.assign(output, { [key]: sourceObj[key] });
 				}
 			});
 		}
 
-		return output;
+		return output as T;
 	}
 }
 
 /**
  * オブジェクトかどうかチェック
  */
-function isObject(item: any): boolean {
-	return item && typeof item === 'object' && !Array.isArray(item);
+function isObject(item: unknown): boolean {
+	return Boolean(item) && typeof item === 'object' && !Array.isArray(item);
 }

--- a/src/lib/services/supabaseService.ts
+++ b/src/lib/services/supabaseService.ts
@@ -1,4 +1,7 @@
 import { supabase } from '$lib/supabaseClient';
+import type { Database } from '$lib/database.types';
+
+type ScoreInsert = Database['public']['Tables']['Score']['Insert'];
 
 export async function saveScore(
 	nickName: string,
@@ -7,7 +10,7 @@ export async function saveScore(
 	gameMode?: 'random' | 'timeattack',
 	time?: number
 ) {
-	const insertData: any = {
+	const insertData: ScoreInsert = {
 		nick_name: nickName,
 		difficulty: difficulty
 	};

--- a/src/lib/services/typing/input-validator.spec.ts
+++ b/src/lib/services/typing/input-validator.spec.ts
@@ -371,8 +371,8 @@ describe('InputValidator', () => {
 		});
 
 		it('nullやundefinedを処理する', () => {
-			expect(validator.getRomajiPatterns(null as any)).toEqual(['']);
-			expect(validator.getRomajiPatterns(undefined as any)).toEqual(['']);
+			expect(validator.getRomajiPatterns(null as unknown as string)).toEqual(['']);
+			expect(validator.getRomajiPatterns(undefined as unknown as string)).toEqual(['']);
 		});
 
 		it('非ひらがな文字を処理する', () => {

--- a/src/lib/services/typing/input-validator.ts
+++ b/src/lib/services/typing/input-validator.ts
@@ -196,7 +196,7 @@ export class InputValidator {
 		}
 
 		// 非ひらがな文字はそのまま返す（長音記号も含む）
-		if (!/[\u3040-\u309F\u30FC\s　]/.test(hiragana)) {
+		if (!/[\u3040-\u309F\u30FC\s\u3000]/.test(hiragana)) {
 			return [hiragana];
 		}
 

--- a/src/lib/services/typing/partial-input-processor.ts
+++ b/src/lib/services/typing/partial-input-processor.ts
@@ -1,9 +1,4 @@
-import type {
-	PartialInputConfig,
-	PartialInputMode,
-	PartialInputRange,
-	PartialInputPreset
-} from '$lib/types';
+import type { PartialInputConfig, PartialInputRange, PartialInputPreset } from '$lib/types';
 
 /**
  * 部分入力モードの処理を管理するクラス

--- a/src/lib/stores/game.spec.ts
+++ b/src/lib/stores/game.spec.ts
@@ -2,10 +2,10 @@
  * ゲーム状態管理ストアのテスト
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { get } from 'svelte/store';
-import { createGameStore, type GameState, type GameSession } from './game';
-import type { KarutaCard, GameMode } from '$lib/types';
+import { createGameStore } from './game';
+import type { KarutaCard } from '$lib/types';
 import { InputValidator } from '../services/typing/input-validator';
 
 // モックデータ
@@ -632,13 +632,17 @@ describe('GameStore - パフォーマンス', () => {
 
 		startSession('practice', mockCards);
 
-		const initialMemory = (performance as any).memory?.usedJSHeapSize || 0;
+		const initialMemory =
+			(performance as Performance & { memory?: { usedJSHeapSize: number } }).memory
+				?.usedJSHeapSize || 0;
 
 		for (let i = 0; i < 100; i++) {
 			updateInput(`test${i}`);
 		}
 
-		const finalMemory = (performance as any).memory?.usedJSHeapSize || 0;
+		const finalMemory =
+			(performance as Performance & { memory?: { usedJSHeapSize: number } }).memory
+				?.usedJSHeapSize || 0;
 		const memoryIncrease = finalMemory - initialMemory;
 
 		// メモリ増加が妥当な範囲内であることを確認

--- a/src/lib/stores/game.ts
+++ b/src/lib/stores/game.ts
@@ -89,6 +89,15 @@ export interface GameProgress {
 	percentage: number;
 }
 
+export interface GameStatisticsSummary {
+	wpm: number;
+	accuracy: number;
+	combo: number;
+	maxCombo: number;
+	totalKeystrokes: number;
+	mistakes: number;
+}
+
 // 初期状態
 const initialState: GameState = {
 	session: null,
@@ -173,7 +182,7 @@ export function createGameStore() {
 	const scoreStore: Readable<GameScore> = derived(stateStore, ($game) => $game.score);
 
 	// 派生ストア: 統計情報（練習モードと同様）
-	const statisticsStore: Readable<any> = derived(stateStore, ($game) => {
+	const statisticsStore: Readable<GameStatisticsSummary> = derived(stateStore, ($game) => {
 		// WPM計算
 		const elapsedMinutes = $game.timer.elapsedTime / 60000;
 		const words = $game.statistics.correctKeystrokes / 5;
@@ -204,7 +213,7 @@ export function createGameStore() {
 		if (cards.length === 0) return;
 
 		let gameCards = [...cards];
-		let allCards = cards; // 元の全カードを保持
+		const allCards = cards; // 元の全カードを保持
 
 		// モードごとの処理
 		if (mode === 'random') {

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -1,12 +1,5 @@
 import { writable, get } from 'svelte/store';
-import type {
-	UserSettings,
-	DisplaySettings,
-	SoundSettings,
-	PracticeSettings,
-	KeyboardSettings,
-	AccessibilitySettings
-} from '$lib/types/game';
+import type { UserSettings } from '$lib/types/game';
 
 // Default settings
 const defaultSettings: UserSettings = {
@@ -98,21 +91,25 @@ const difficultyPresets = {
 function createSettingsStore() {
 	const { subscribe, set, update } = writable<UserSettings>(defaultSettings);
 
-	let savedSettings: UserSettings = { ...defaultSettings };
 	let changedPaths = new Set<string>();
 
 	// Helper function to get nested property
-	function getNestedProperty(obj: any, path: string): any {
-		return path.split('.').reduce((current, key) => current?.[key], obj);
+	function getNestedProperty(obj: Record<string, unknown>, path: string): unknown {
+		return path
+			.split('.')
+			.reduce<unknown>(
+				(current, key) => (current as Record<string, unknown> | undefined)?.[key],
+				obj
+			);
 	}
 
 	// Helper function to set nested property
-	function setNestedProperty(obj: any, path: string, value: any): void {
+	function setNestedProperty(obj: Record<string, unknown>, path: string, value: unknown): void {
 		const keys = path.split('.');
 		const lastKey = keys.pop()!;
-		const target = keys.reduce((current, key) => {
+		const target = keys.reduce<Record<string, unknown>>((current, key) => {
 			if (!current[key]) current[key] = {};
-			return current[key];
+			return current[key] as Record<string, unknown>;
 		}, obj);
 		target[lastKey] = value;
 	}
@@ -122,7 +119,7 @@ function createSettingsStore() {
 		return Math.max(min, Math.min(max, value));
 	}
 
-	function validateValue(path: string, value: any): any {
+	function validateValue(path: string, value: unknown): unknown {
 		// Numeric range validations
 		const rangeValidations: Record<string, { min: number; max: number }> = {
 			partialLength: { min: 3, max: 10 },
@@ -135,7 +132,7 @@ function createSettingsStore() {
 
 		if (rangeValidations[path]) {
 			const { min, max } = rangeValidations[path];
-			return validateRange(value, min, max);
+			return validateRange(value as number, min, max);
 		}
 
 		// Enum validations
@@ -149,9 +146,9 @@ function createSettingsStore() {
 			'keyboard.inputMethod': ['romaji', 'kana']
 		};
 
-		if (enumValidations[path] && !enumValidations[path].includes(value)) {
+		if (enumValidations[path] && !enumValidations[path].includes(value as string)) {
 			// Return current value if invalid
-			return getNestedProperty(get({ subscribe }), path);
+			return getNestedProperty(get({ subscribe }) as unknown as Record<string, unknown>, path);
 		}
 
 		return value;
@@ -164,12 +161,12 @@ function createSettingsStore() {
 		getDefaults: () => defaultSettings,
 
 		// Update a specific setting
-		updateSetting: (path: string, value: any) => {
+		updateSetting: (path: string, value: unknown) => {
 			const validatedValue = validateValue(path, value);
 
 			update((settings) => {
 				const newSettings = { ...settings };
-				setNestedProperty(newSettings, path, validatedValue);
+				setNestedProperty(newSettings as unknown as Record<string, unknown>, path, validatedValue);
 				changedPaths.add(path);
 				return newSettings;
 			});
@@ -205,7 +202,6 @@ function createSettingsStore() {
 			const settings = get({ subscribe });
 			try {
 				localStorage.setItem('userSettings', JSON.stringify(settings));
-				savedSettings = { ...settings };
 				changedPaths.clear();
 			} catch (error) {
 				console.error('Failed to save settings:', error);
@@ -237,7 +233,6 @@ function createSettingsStore() {
 						accessibility: { ...defaultSettings.accessibility, ...parsed.accessibility }
 					};
 					set(merged);
-					savedSettings = { ...merged };
 				}
 			} catch (error) {
 				console.error('Failed to load settings:', error);
@@ -248,7 +243,6 @@ function createSettingsStore() {
 		// Reset all settings to default
 		reset: () => {
 			set(defaultSettings);
-			savedSettings = { ...defaultSettings };
 			changedPaths.clear();
 		},
 
@@ -261,7 +255,9 @@ function createSettingsStore() {
 
 				if (section in defaultSettings) {
 					// For top-level properties
-					(newSettings as any)[section] = (defaultSettings as any)[section];
+					(newSettings as unknown as Record<string, unknown>)[section] = (
+						defaultSettings as unknown as Record<string, unknown>
+					)[section];
 				} else {
 					// For nested sections
 					switch (section) {
@@ -334,7 +330,6 @@ function createSettingsStore() {
 				};
 
 				set(merged);
-				savedSettings = { ...merged };
 				changedPaths.clear();
 			} catch (error) {
 				console.error('Failed to import settings:', error);

--- a/src/lib/stores/statistics.spec.ts
+++ b/src/lib/stores/statistics.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { get } from 'svelte/store';
 import { statisticsStore } from './statistics';
-import type { SessionStats, OverallStats, CardStats, FilterOptions } from '$lib/types/game';
+import type { SessionStats, FilterOptions } from '$lib/types/game';
 
 // Mock IndexedDB service
 vi.mock('$lib/services/storage/indexed-db', () => ({
@@ -218,27 +218,27 @@ describe('Statistics Store', () => {
 		});
 
 		it('TC-026: should load statistics from storage', async () => {
-			const mockStats = {
-				overall: {
-					totalSessions: 5,
-					totalPlayTime: 300000,
-					totalKeysTyped: 500,
-					totalCardsCompleted: 50,
-					averageWPM: 55,
-					maxWPM: 70,
-					averageAccuracy: 93,
-					maxAccuracy: 100,
-					currentStreak: 2,
-					longestStreak: 5,
-					totalScore: 5000,
-					level: 3,
-					rank: '中級'
-				},
-				sessions: [],
-				cardStats: new Map()
-			};
-
 			// TODO: Fix when getStatistics is implemented in IndexedDBService
+			// Once available, mock the resolved statistics like so:
+			// const mockStats = {
+			//   overall: {
+			//     totalSessions: 5,
+			//     totalPlayTime: 300000,
+			//     totalKeysTyped: 500,
+			//     totalCardsCompleted: 50,
+			//     averageWPM: 55,
+			//     maxWPM: 70,
+			//     averageAccuracy: 93,
+			//     maxAccuracy: 100,
+			//     currentStreak: 2,
+			//     longestStreak: 5,
+			//     totalScore: 5000,
+			//     level: 3,
+			//     rank: '中級'
+			//   },
+			//   sessions: [],
+			//   cardStats: new Map()
+			// };
 			// const { IndexedDBService } = await import('$lib/services/storage/indexed-db');
 			// const mockInstance = new IndexedDBService();
 			// vi.mocked(mockInstance.getStatistics).mockResolvedValue(mockStats);

--- a/src/lib/stores/statistics.ts
+++ b/src/lib/stores/statistics.ts
@@ -1,14 +1,11 @@
-import { writable, derived, get } from 'svelte/store';
+import { writable, get } from 'svelte/store';
 import type {
 	OverallStats,
 	SessionStats,
 	CardStats,
 	FilterOptions,
-	TrendData,
-	GameMode
+	TrendData
 } from '$lib/types/game';
-import { IndexedDBService } from '$lib/services/storage/indexed-db';
-
 interface StatisticsState {
 	overall: OverallStats;
 	sessions: SessionStats[];
@@ -23,7 +20,6 @@ interface FilteredStats {
 }
 
 function createStatisticsStore() {
-	const db = new IndexedDBService();
 	const initialState: StatisticsState = {
 		overall: {
 			totalSessions: 0,
@@ -298,7 +294,11 @@ function createStatisticsStore() {
 
 			try {
 				// TODO: Implement getStatistics in IndexedDBService
-				const data = null as any; // await db.getStatistics();
+				const data = null as {
+					sessions?: SessionStats[];
+					overall?: OverallStats;
+					cardStats?: Map<string, CardStats>;
+				} | null; // await db.getStatistics();
 				if (data) {
 					const overall = calculateOverallStats(data.sessions || []);
 					update((state) => ({
@@ -421,7 +421,6 @@ function createStatisticsStore() {
 			});
 
 			try {
-				const state = get({ subscribe });
 				// TODO: Implement updateCardStats in IndexedDBService
 				// await db.updateCardStats(cardId, state.cardStats.get(cardId)!);
 			} catch (error) {
@@ -460,15 +459,22 @@ function createStatisticsStore() {
 		importData: async (data: string, format: 'json' | 'csv') => {
 			try {
 				if (format === 'json') {
-					const parsed = JSON.parse(data);
-					const sessions = parsed.sessions.map((s: any) => ({
+					const parsed: {
+						overall?: OverallStats;
+						sessions: (Omit<SessionStats, 'timestamp'> & { timestamp: string | number | Date })[];
+						cardStats?: (Omit<CardStats, 'lastPlayed'> & {
+							id?: string;
+							lastPlayed: string | number | Date;
+						})[];
+					} = JSON.parse(data);
+					const sessions: SessionStats[] = parsed.sessions.map((s) => ({
 						...s,
 						timestamp: new Date(s.timestamp)
 					}));
 
-					const cardStats = new Map();
+					const cardStats = new Map<string, CardStats>();
 					if (parsed.cardStats) {
-						parsed.cardStats.forEach((stats: any) => {
+						parsed.cardStats.forEach((stats) => {
 							cardStats.set(stats.id || stats.cardId, {
 								...stats,
 								lastPlayed: new Date(stats.lastPlayed)

--- a/src/lib/utils/image-preloader.ts
+++ b/src/lib/utils/image-preloader.ts
@@ -50,7 +50,7 @@ export class ImagePreloader {
 	 * カード画像をプリロード
 	 */
 	static async preloadCardImages(card: KarutaCard): Promise<void> {
-		const promises: Promise<any>[] = [];
+		const promises: Promise<unknown>[] = [];
 
 		if (card.images?.torifuda) {
 			promises.push(this.preloadImage(card.images.torifuda).catch(() => {}));

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import '../app.css';
 	import favicon from '$lib/assets/favicon.ico';
-	import { onMount } from 'svelte';
+	import { onMount, type Snippet } from 'svelte';
 	import { settingsStore } from '$lib/stores/settings';
 	import { authStore } from '$lib/stores/auth';
 	import { invalidate } from '$app/navigation';
 	import type { LayoutData } from './$types';
 
-	let { children, data }: { children: any; data: LayoutData } = $props();
+	let { children, data }: { children: Snippet; data: LayoutData } = $props();
 
 	// アプリケーション起動時に設定を読み込む
 	onMount(() => {

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,7 +1,7 @@
 import { createSupabaseBrowserClient } from '$lib/supabase/browser';
 import type { LayoutLoad } from './$types';
 
-export const load: LayoutLoad = async ({ data, depends, fetch }) => {
+export const load: LayoutLoad = async ({ data, depends }) => {
 	depends('supabase:auth');
 
 	const supabase = createSupabaseBrowserClient();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import type { ResolvedPathname } from '$app/types';
 	import type { GameMode, RandomModeDifficulty } from '$lib/types';
 	import type { PageData } from './$types';
 
@@ -98,22 +100,22 @@
 			mode: gameMode,
 			difficulty
 		});
-		goto(`/game?${params.toString()}`);
+		goto(`${resolve('/game')}?${params.toString()}` as ResolvedPathname);
 	}
 
 	function navigateToGame(mode: GameMode) {
 		// 特定札練習モードは専用ページへ
 		if (mode === 'specific') {
-			goto('/practice/specific');
+			goto(resolve('/practice/specific'));
 			return;
 		}
 
 		const params = new URLSearchParams({ mode });
-		goto(`/game?${params.toString()}`);
+		goto(`${resolve('/game')}?${params.toString()}` as ResolvedPathname);
 	}
 
-	function handleNavigation(path: string) {
-		goto(path);
+	function handleNavigation(path: '/ranking' | '/settings' | '/statistics') {
+		goto(resolve(path));
 	}
 
 	function handleRetry() {
@@ -206,7 +208,7 @@
 					<span>遊び方</span>
 				</button>
 				<a
-					href="/ranking"
+					href={resolve('/ranking')}
 					onclick={(e) => {
 						e.preventDefault();
 						handleNavigation('/ranking');
@@ -217,7 +219,7 @@
 					<span>ランキング</span>
 				</a>
 				<a
-					href="/settings"
+					href={resolve('/settings')}
 					onclick={(e) => {
 						e.preventDefault();
 						handleNavigation('/settings');
@@ -228,7 +230,7 @@
 					<span>設定</span>
 				</a>
 				<a
-					href="/statistics"
+					href={resolve('/statistics')}
 					onclick={(e) => {
 						e.preventDefault();
 						handleNavigation('/statistics');

--- a/src/routes/auth/error/+page.svelte
+++ b/src/routes/auth/error/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { resolve } from '$app/paths';
 
 	let countdown = $state(5);
 
@@ -45,7 +46,7 @@
 		</p>
 
 		<a
-			href="/auth/login"
+			href={resolve('/auth/login')}
 			class="inline-flex items-center px-6 py-3 bg-blue-600 text-white font-medium rounded-md hover:bg-blue-700 transition-colors"
 		>
 			ログイン画面に戻る

--- a/src/routes/auth/signup/+page.svelte
+++ b/src/routes/auth/signup/+page.svelte
@@ -1,6 +1,7 @@
 <!-- TODO: email passwordによる登録は一旦非表示 -->
 
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import type { ActionData } from './$types';
 
 	let { form }: { form: ActionData } = $props();
@@ -172,11 +173,18 @@
 							class="mt-1 mr-2 h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
 						/>
 						<span class="text-sm text-gray-600">
-							<a href="/terms" class="text-blue-600 hover:text-blue-700" target="_blank">利用規約</a
+							<a
+								href="/terms"
+								class="text-blue-600 hover:text-blue-700"
+								target="_blank"
+								rel="external">利用規約</a
 							>
 							および
-							<a href="/privacy" class="text-blue-600 hover:text-blue-700" target="_blank"
-								>プライバシーポリシー</a
+							<a
+								href="/privacy"
+								class="text-blue-600 hover:text-blue-700"
+								target="_blank"
+								rel="external">プライバシーポリシー</a
 							>
 							に同意します
 						</span>
@@ -194,7 +202,7 @@
 		{/if}
 
 		<div class="mt-6 text-center">
-			<a href="/auth/login" class="text-blue-600 hover:text-blue-700 text-sm">
+			<a href={resolve('/auth/login')} class="text-blue-600 hover:text-blue-700 text-sm">
 				既にアカウントをお持ちの方はこちら
 			</a>
 		</div>

--- a/src/routes/game/+page.svelte
+++ b/src/routes/game/+page.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte';
 	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import { SvelteSet } from 'svelte/reactivity';
 	import { get } from 'svelte/store';
-	import { gameStore } from '$lib/stores/game';
+	import { gameStore, type GameScore } from '$lib/stores/game';
 	import { InputValidator } from '$lib/services/typing/input-validator';
 	import { TypingSoundManager } from '$lib/services/audio/typing-sounds';
 	import type { GameMode, KarutaCard, RandomModeDifficulty } from '$lib/types';
@@ -58,8 +60,13 @@
 	let cardIndex = $state(0);
 	let totalCards = $state(44);
 	let completedCardsCount = $state(0);
-	let mistakes = $state(0);
-	let score = $state<any>({});
+	let score = $state<GameScore>({
+		total: 0,
+		accuracy: 100,
+		speed: 0,
+		combo: 0,
+		maxCombo: 0
+	});
 	let isPaused = $state(false);
 	let elapsedTime = $state(0);
 	let pauseCount = $state(0);
@@ -112,7 +119,6 @@
 					currentCard = state.cards.current;
 					cardIndex = state.cards.currentIndex;
 					completedCardsCount = state.cards.completed.length;
-					mistakes = state.input.mistakes;
 					score = state.score;
 					isPaused = state.timer.isPaused;
 					elapsedTime = state.timer.elapsedTime;
@@ -538,8 +544,6 @@
 				romajiStates[i] = 'pending';
 			}
 
-			mistakes++;
-
 			// 間違った入力の音を再生
 			soundManager?.playIncorrect();
 
@@ -688,7 +692,7 @@
 		if (!validator || !currentCard) return;
 		// displayHiraganaが空の場合は初期化
 		if (!displayHiragana) {
-			const state = get(gameStore.gameStore) as any;
+			const state = get(gameStore.gameStore);
 			const hiraganaText =
 				state.session?.difficulty === 'beginner' &&
 				'hiraganaShort' in currentCard &&
@@ -820,7 +824,7 @@
 								usedPattern = 'n';
 							} else {
 								const nextPatterns = validator.getRomajiPatterns(nextUnit);
-								const initials = new Set<string>();
+								const initials = new SvelteSet<string>();
 								nextPatterns.forEach((p) => {
 									if (p && p.length > 0) initials.add(p[0]);
 								});
@@ -973,7 +977,7 @@
 		gameStore.endSession(true);
 		soundManager?.stopCardReading();
 		soundManager?.stopBGM();
-		goto('/');
+		goto(resolve('/'));
 	}
 
 	function cancelExit() {
@@ -991,7 +995,7 @@
 		if (!currentCard) return;
 		// displayHiraganaが空の場合は初期化（最初のカード用）
 		if (!displayHiragana) {
-			const state = get(gameStore.gameStore) as any;
+			const state = get(gameStore.gameStore);
 			const hiraganaText =
 				state.session?.difficulty === 'beginner' &&
 				'hiraganaShort' in currentCard &&
@@ -1040,7 +1044,7 @@
 			<!-- エラー状態 -->
 			<div class="rounded-lg border border-red-200 bg-red-50 p-6 text-center">
 				<p class="mb-4 text-red-600">{error}</p>
-				<a href="/" class="text-blue-600 hover:underline">メインメニューに戻る</a>
+				<a href={resolve('/')} class="text-blue-600 hover:underline">メインメニューに戻る</a>
 			</div>
 		{:else if isGameComplete}
 			<!-- 
@@ -1137,7 +1141,7 @@
 					{/if}
 					<div class="grid grid-cols-2 gap-3">
 						<button
-							onclick={() => goto('/ranking')}
+							onclick={() => goto(resolve('/ranking'))}
 							class="rounded-lg border border-gray-300 bg-white px-6 py-3 text-gray-700 transition-colors hover:bg-gray-50"
 						>
 							🏆 ランキングを見る
@@ -1173,7 +1177,7 @@ ${gameMode === 'specific' ? '特定札練習' : gameMode === 'practice' ? '練�
 
 							// 特定札練習モードの場合は特定札選択画面に戻る
 							if (gameMode === 'specific') {
-								goto('/practice/specific');
+								goto(resolve('/practice/specific'));
 							} else {
 								// その他のモードは同じモードで再プレイ
 								const url = new URL(window.location.href);
@@ -1190,7 +1194,7 @@ ${gameMode === 'specific' ? '特定札練習' : gameMode === 'practice' ? '練�
 						{gameMode === 'specific' ? '札を選び直す' : 'もう一度遊ぶ'}
 					</button>
 					<button
-						onclick={() => goto('/')}
+						onclick={() => goto(resolve('/'))}
 						class="rounded-lg border border-gray-300 bg-white px-6 py-3 text-gray-700 transition-colors hover:bg-gray-50"
 					>
 						メインメニューに戻る

--- a/src/routes/game/game.spec.ts
+++ b/src/routes/game/game.spec.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import { render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { goto } from '$app/navigation';
 import { page } from '$app/stores';
-import { get } from 'svelte/store';
+import { writable } from 'svelte/store';
 import Page from './+page.svelte';
 
 // Mock modules
@@ -23,7 +23,6 @@ vi.mock('$app/stores', () => ({
 
 // Mock game store
 vi.mock('$lib/stores/game', () => {
-	const { writable } = require('svelte/store');
 	const mockGameStore = writable({
 		session: null,
 		cards: {
@@ -117,8 +116,8 @@ describe('Game Page', () => {
 		it('TC-001: should get game mode from URL parameters', async () => {
 			render(Page);
 
-			await waitFor(() => {
-				const { gameStore } = require('$lib/stores/game');
+			await waitFor(async () => {
+				const { gameStore } = await import('$lib/stores/game');
 				expect(gameStore.startSession).toHaveBeenCalledWith(
 					expect.objectContaining({
 						mode: 'practice'
@@ -138,8 +137,8 @@ describe('Game Page', () => {
 
 			render(Page);
 
-			await waitFor(() => {
-				const { gameStore } = require('$lib/stores/game');
+			await waitFor(async () => {
+				const { gameStore } = await import('$lib/stores/game');
 				expect(gameStore.startSession).toHaveBeenCalledWith(
 					expect.objectContaining({
 						mode: 'practice',

--- a/src/routes/page.spec.ts
+++ b/src/routes/page.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import { render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { goto } from '$app/navigation';
 import Page from './+page.svelte';
@@ -318,7 +318,7 @@ describe('MainMenu Page', () => {
 				startedAt: new Date(),
 				completedCards: 10,
 				totalCards: 44
-			} as any);
+			});
 
 			render(Page);
 

--- a/src/routes/practice/specific/+page.svelte
+++ b/src/routes/practice/specific/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import type { ResolvedPathname } from '$app/types';
 	import { onMount } from 'svelte';
 	import CardSelector from '$lib/components/specific/CardSelector.svelte';
 	import FavoritesManager from '$lib/components/specific/FavoritesManager.svelte';
@@ -44,11 +46,13 @@
 
 		// 札の並び（重複・順序）を保持したままURLで特定札モードへ遷移
 		const cardIds = practiceCards.map((card) => card.id).join(',');
-		await goto(`/game?mode=specific&cards=${encodeURIComponent(cardIds)}`);
+		await goto(
+			`${resolve('/game')}?mode=specific&cards=${encodeURIComponent(cardIds)}` as ResolvedPathname
+		);
 	}
 
 	function goBack() {
-		goto('/');
+		goto(resolve('/'));
 	}
 </script>
 

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
@@ -10,7 +11,7 @@
 			<div class="flex items-center justify-between mb-6">
 				<h1 class="text-3xl font-bold text-gray-800">プロフィール</h1>
 				<div class="flex gap-4">
-					<a href="/auth/logout" class="text-red-600 hover:text-red-700 font-medium">
+					<a href={resolve('/auth/logout')} class="text-red-600 hover:text-red-700 font-medium">
 						ログアウト
 					</a>
 				</div>
@@ -27,7 +28,7 @@
 						<div>
 							<p class="text-sm text-gray-500">ニックネーム</p>
 							<p class="text-gray-800">
-								{(data.profile as any)?.nickname || data.user?.email?.split('@')[0]}
+								{data.profile?.nickname || data.user?.email?.split('@')[0]}
 							</p>
 						</div>
 						<div>
@@ -102,7 +103,7 @@
 
 		<div class="mt-8 text-center">
 			<a
-				href="/"
+				href={resolve('/')}
 				class="inline-flex items-center px-6 py-3 bg-blue-600 text-white font-medium rounded-md hover:bg-blue-700 transition-colors"
 			>
 				ホームに戻る

--- a/src/routes/ranking/+page.svelte
+++ b/src/routes/ranking/+page.svelte
@@ -3,6 +3,7 @@
 	import { getTopScoresByDifficulty, getTopTimesByDifficulty } from '$lib/services/supabaseService';
 	import { ArrowLeft, Trophy, Medal, Award, Timer, Zap } from '@lucide/svelte';
 	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
 	import type { RandomModeDifficulty } from '$lib/types';
 
 	type GameModeType = 'random' | 'timeattack';
@@ -84,7 +85,7 @@
 		<!-- ヘッダー -->
 		<div class="mb-8 flex items-center justify-between">
 			<button
-				onclick={() => goto('/')}
+				onclick={() => goto(resolve('/'))}
 				class="flex items-center gap-2 rounded-lg px-4 py-2 text-gray-700 transition-colors hover:bg-gray-100"
 			>
 				<ArrowLeft class="h-4 w-4" />
@@ -215,7 +216,7 @@
 								</tr>
 							</thead>
 							<tbody>
-								{#each rankings as entry, index}
+								{#each rankings as entry, index (entry.id)}
 									{@const rank = index + 1}
 									{@const Icon = getRankIcon(rank)}
 									<tr class="border-b border-gray-100 transition-colors hover:bg-gray-50">

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
 	import { settingsStore } from '$lib/stores/settings';
 	import SettingItem from '$lib/components/settings/SettingItem.svelte';
 
@@ -89,7 +90,7 @@
 				hasUnsavedChanges = false;
 			}
 		} else {
-			goto('/');
+			goto(resolve('/'));
 		}
 	}
 
@@ -100,7 +101,7 @@
 
 	function confirmReset() {
 		if (resetSection) {
-			settingsStore.resetSection(resetSection as any);
+			settingsStore.resetSection(resetSection as Parameters<typeof settingsStore.resetSection>[0]);
 		} else {
 			settingsStore.reset();
 		}
@@ -187,7 +188,7 @@
 	<div class="settings-content">
 		<!-- Sidebar -->
 		<nav class="settings-sidebar">
-			{#each sections as section}
+			{#each sections as section (section.id)}
 				<button
 					onclick={() => (activeSection = section.id)}
 					class="sidebar-item {activeSection === section.id ? 'active' : ''}"

--- a/src/routes/statistics/+page.svelte
+++ b/src/routes/statistics/+page.svelte
@@ -60,7 +60,7 @@
 	async function applyFilters() {
 		const filters: FilterOptions = {
 			period: selectedPeriod === 'all' ? undefined : selectedPeriod,
-			mode: selectedMode === 'all' ? undefined : (selectedMode as any)
+			mode: selectedMode === 'all' ? undefined : selectedMode
 		};
 
 		const filtered = await statisticsStore.getFilteredStats(filters);
@@ -141,12 +141,12 @@
 	}
 
 	async function handlePeriodChange(event: Event) {
-		selectedPeriod = (event.target as HTMLSelectElement).value as any;
+		selectedPeriod = (event.target as HTMLSelectElement).value as typeof selectedPeriod;
 		await applyFilters();
 	}
 
 	async function handleModeChange(event: Event) {
-		selectedMode = (event.target as HTMLSelectElement).value as any;
+		selectedMode = (event.target as HTMLSelectElement).value as typeof selectedMode;
 		await applyFilters();
 	}
 
@@ -303,7 +303,7 @@
 							</tr>
 						</thead>
 						<tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-							{#each filteredStats.sessions.slice(0, 10) as session}
+							{#each filteredStats.sessions.slice(0, 10) as session (session.id)}
 								<tr>
 									<td class="px-6 py-4 text-sm whitespace-nowrap">
 										{new Date(session.timestamp).toLocaleDateString('ja-JP')}


### PR DESCRIPTION
## 概要

`bun --bun run lint` で発生していた **108件のエラーをすべて解消**しました。

| チェック | 変更前 | 変更後 |
|---|---|---|
| `bun --bun run lint` | 108 errors | ✅ 0 errors |
| `bun --bun run check`（型チェック） | 0 errors | ✅ 0 errors（回帰なし） |
| テスト | 58 failed（既存の赤いベースライン） | 同一（新規失敗ゼロ） |

## ルール別の対応（108件）

| ルール | 件数 | 対応 |
|---|---|---|
| `@typescript-eslint/no-explicit-any` | 48 | `any` を実型／`unknown`+ナローイングへ置換（`any` は一切残さず） |
| `svelte/no-navigation-without-resolve` | 25 | `goto()`／`href` を `resolve()` でラップ |
| `@typescript-eslint/no-unused-vars` | 26 | 未使用 import／変数を削除 |
| `@typescript-eslint/no-require-imports` | 3 | `require()` → `await import()` |
| `svelte/require-each-key` | 3 | `{#each}` に一意キーを付与 |
| `prefer-const` / `svelte/prefer-svelte-reactivity` / `no-irregular-whitespace` | 各1 | `const`化 / `SvelteSet`化 / 全角スペースのエスケープ化 |

## 要注意ポイント

- **`eslint.config.js`**: `^_` プレフィックスの意図的未使用変数を許可する標準設定を追加。`{#each Array(5) as _, i}` のように Svelte 構文上 `_` を削除できない箇所に対応するため（typescript-eslint 推奨の慣用設定）。
- **`input-validator.ts`**: 正規表現 `[…\s　]` 内の全角スペース（U+3000）リテラルを `　` エスケープへ変更。**正規表現の意味は不変**。
- **`auth/signup` の `/terms`・`/privacy`**: アプリにルートが存在しない既存の dead link。`resolve()` 化すると型エラーになるため `rel="external"` を付与（lint ルールの正規の除外パターン。挙動は現状維持）。

## コミット構成

1. `chore(lint): ESLint エラー108件を解消` — lint 修正本体（27ファイル）
2. `chore(deps): @opentelemetry/api を依存に追加` — `@opentelemetry/api@1.9.1` を dependencies へ追加（lint 作業とは別件だが本PRに同梱）

型チェック・テストともにベースラインから回帰がないことを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)